### PR TITLE
Support nil parameter when using adopt policy

### DIFF
--- a/luabind/adopt_policy.hpp
+++ b/luabind/adopt_policy.hpp
@@ -65,7 +65,11 @@ namespace luabind { namespace detail
 
             object_rep* obj = static_cast<object_rep*>(
                 lua_touserdata(L, index));
-            obj->release();
+
+            if (obj)
+            {
+                obj->release();
+            }
 
             adjust_backref_ownership(ptr, boost::is_polymorphic<T>());
 


### PR DESCRIPTION
Test if pointer is null and only release if that is the case.
This way nil can be passed from Lua to C++ as null when using the adopt policy
without crashing the application (by trying to access a member of a null pointer).

This patch is also [included in Debian](https://sources.debian.org/patches/luabind/0.9.1+dfsg-11/11_fix_potential_null_ptr_dereference_in_adopt_policy.patch/) since stretch.