### PR TITLE
Allow to throw luabind::error from ~proxy_member_void_caller()

### DIFF
--- a/luabind/detail/call_member.hpp
+++ b/luabind/detail/call_member.hpp
@@ -230,7 +230,7 @@ namespace luabind
                     rhs.m_called = true;
                 }
 
-                ~proxy_member_void_caller()
+                ~proxy_member_void_caller() LUABIND_MAY_THROW
                 {
                     if (m_called) return;
 


### PR DESCRIPTION
Prevent some chances of std::terminate being called in ~proxy_member_void_caller()

This should complete the change made by 94fedc64.