### PR TITLE
added power support arch ppc64le on yml file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,10 @@ jobs:
           env: C_CXX11=OFF C_LUAV=5.1.5 C_LXX=src
         - compiler: clang
           env: C_CXX11=OFF C_LUAV=5.3.4 C_LXX=cxx C_EXTRA="-DLUABIND_CPLUSPLUS_LUA=ON"
-
+          # added power support arch ppc64le.
+        - compiler: clang
+          env: C_CXX11=OFF C_LUAV=5.1.5 C_LXX=src
+          arch: ppc64le
+        - compiler: clang
+          env: C_CXX11=OFF C_LUAV=5.3.4 C_LXX=cxx C_EXTRA="-DLUABIND_CPLUSPLUS_LUA=ON"
+          arch: ppc64le


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.
continuous integration build has passed without any failures after added power support arch ppc64le.kindly check and merge this component.

